### PR TITLE
HS-3168-Preview does not display message when only some keywords match

### DIFF
--- a/src/components/ui/Results/AllKeywordNotMatched.tsx
+++ b/src/components/ui/Results/AllKeywordNotMatched.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+
+import { useHawksearch } from 'components/StoreProvider';
+import { useTranslation } from 'react-i18next';
+
+function AllKeywordNotMatched() {
+	const {
+		store: { pendingSearch, searchResults },
+	} = useHawksearch();
+	const [message, setMessage] = useState('');
+
+	const { t, i18n } = useTranslation();
+	useEffect(() => {
+		if (searchResults && !searchResults.QueryUsedAllKeywords) {
+			setMessage('Sorry, No items contained all of the word in your query. These results below contains some of the words.');
+		} 
+	}, [searchResults]); 
+
+
+	if (!pendingSearch.Keyword) {
+		// no selections, so render nothing
+		return null;
+	}
+
+	if (searchResults && searchResults.QueryUsedAllKeywords) {
+		return null;
+	}
+
+	return (
+		<div className="hawk-result-rail__keyword-not-match">
+			<h6 >{pendingSearch.Keyword ? message : '' }</h6>
+		</div>
+	);
+}
+
+export default AllKeywordNotMatched;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { default as FacetList } from 'components/ui/Facets/FacetList';
 export { default as Facet } from 'components/ui/Facets/Facet';
 export { default as Selections } from 'components/ui/Facets/Selections';
 export { default as SearchResultsLabel } from 'components/ui/Facets/SearchResultsLabel';
+export { default as AllKeywordNotMatched } from 'components/ui/Results/AllKeywordNotMatched';
 export * from 'components/ui/Facets/FacetTypes';
 export { FacetType } from 'models/Facets/FacetType';
 export { FacetSelectionState } from 'store/Store';

--- a/src/styles/components/_hawk-facet-rail.scss
+++ b/src/styles/components/_hawk-facet-rail.scss
@@ -271,6 +271,10 @@
 	display: block
 }
 
+.hawk-result-rail__keyword-not-match {
+	color:#ff0000;
+}
+
 .hawk-facet-rail__facet-btn {
 	@include ButtonLink;
 


### PR DESCRIPTION
Task: To improve user experience and clarity by adding message for partial keyword matches in search results in Preview across all ES engines. 
Functionality included: 
- Trigger: when there’s no search results for the entire search query and the search results returned are based on some of the search query
- Message: Sorry, no items contained all of the words in your query. These results below contain some of the words.